### PR TITLE
feat: add hover circle background to sidebar menu

### DIFF
--- a/src/modules/navigation/menu/components/sidebar-link/sidebar-link.tsx
+++ b/src/modules/navigation/menu/components/sidebar-link/sidebar-link.tsx
@@ -44,7 +44,7 @@ export default function SidebarItem({
     <li className='flex items-center justify-center w-fit h-fit hover:cursor-pointer'>
       {/* Link */}
       <Link
-        className='flex items-center justify-center h-fit w-fit dark:text-[#ecece]'
+        className='flex items-center justify-center h-fit w-fit p-2 rounded-full transition-colors duration-300 hover:bg-[#F4F4F4] dark:hover:bg-[#848489] dark:text-[#ecece]'
         href={href}
         onClick={() => {
           const audio = new Audio('/sounds/click.mp3')


### PR DESCRIPTION
## Summary
- display a circular background around sidebar icons on hover

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68967002e654832796131bcf7148a83c