### PR TITLE
feat: add dark mode icons for publications menu

### DIFF
--- a/src/layouts/aside/panels/components/options/manage-options.tsx
+++ b/src/layouts/aside/panels/components/options/manage-options.tsx
@@ -4,68 +4,77 @@
 import OptionButton from '@/modules/configuration/settings-panel/buttons/option-button'
 
 // Icons
+import chatDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/messages/chats-dark-icon.svg'
 import chatWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/messages/chats-light-icon.svg'
+import eventsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/feeds/events-dark-icon.svg'
 import eventsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/feeds/events-light-icon.svg'
+import liveDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/streaming/live-dark-icon.svg'
 import liveWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/streaming/live-light-icon.svg'
+import productsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/e-commerce/products-dark-icon.svg'
 import productsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/e-commerce/products-light-icon.svg'
+import shortsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/streaming/shorts-dark-icon.svg'
 import shortsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/streaming/shorts-light-icon.svg'
+import storyDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/feeds/stories-dark-icon.svg'
 import storyWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/feeds/stories-light-icon.svg'
+import videosDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/streaming/videos-dark-icon.svg'
 import videosWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/streaming/videos-light-icon.svg'
 
 // Intl
 import { useTranslations } from 'next-intl'
+import { useThemeContext } from '@/modules/configuration/settings-panel/hooks/useThemeContext'
 
 const ManageOptions = () => {
   const t = useTranslations('Posts')
+  const { activeTheme } = useThemeContext()
   return (
     <section className='w-full h-fit flex flex-col'>
       <OptionButton
         label={t('stories')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={storyWhiteSVG}
+        iconSrc={activeTheme === 'light' ? storyWhiteSVG : storyDarkSVG}
         altText={t('stories')}
       />
       <OptionButton
         label={t('events')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={eventsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? eventsWhiteSVG : eventsDarkSVG}
         altText={t('events')}
       />
       <OptionButton
         label={t('products')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={productsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? productsWhiteSVG : productsDarkSVG}
         altText={t('products')}
       />
       <OptionButton
         label={t('shorts')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={shortsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? shortsWhiteSVG : shortsDarkSVG}
         altText={t('shorts')}
       />
       <OptionButton
         label={t('videos')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={videosWhiteSVG}
+        iconSrc={activeTheme === 'light' ? videosWhiteSVG : videosDarkSVG}
         altText={t('videos')}
       />
       <OptionButton
         label={t('live')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={liveWhiteSVG}
+        iconSrc={activeTheme === 'light' ? liveWhiteSVG : liveDarkSVG}
         altText={t('live')}
       />
       <OptionButton
         label={t('comments')}
         isSelected={false}
         onClick={() => {}}
-        iconSrc={chatWhiteSVG}
+        iconSrc={activeTheme === 'light' ? chatWhiteSVG : chatDarkSVG}
         altText={t('comments')}
       />
     </section>

--- a/src/layouts/aside/panels/components/options/publish-options.tsx
+++ b/src/layouts/aside/panels/components/options/publish-options.tsx
@@ -5,14 +5,22 @@ import OptionButton from '@/modules/configuration/settings-panel/buttons/option-
 
 // Custom
 import { usePost } from '@/modules/publications/add-post/hooks/usePost'
+import { useThemeContext } from '@/modules/configuration/settings-panel/hooks/useThemeContext'
 
 // Icons
+import audioDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/streaming/audio-dark-icon.svg'
 import audioWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/streaming/audio-light-icon.svg'
+import eventsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/feeds/events-dark-icon.svg'
 import eventsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/feeds/events-light-icon.svg'
+import productsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/e-commerce/products-dark-icon.svg'
 import productsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/e-commerce/products-light-icon.svg'
+import reviewsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/feeds/reviews-dark-icon.svg'
 import reviewsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/feeds/reviews-light-icon.svg'
+import shortsDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/streaming/shorts-dark-icon.svg'
 import shortsWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/streaming/shorts-light-icon.svg'
+import storyDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/feeds/stories-dark-icon.svg'
 import storyWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/feeds/stories-light-icon.svg'
+import videosDarkSVG from '@/assets/icons/navigation/inactive/dark-theme/streaming/videos-dark-icon.svg'
 import videosWhiteSVG from '@/assets/icons/navigation/inactive/light-theme/streaming/videos-light-icon.svg'
 
 // Intl
@@ -20,6 +28,7 @@ import { useTranslations } from 'next-intl'
 
 const PublishOptions = () => {
   const { changePost } = usePost()
+  const { activeTheme } = useThemeContext()
   const t = useTranslations('Posts')
 
   return (
@@ -28,49 +37,49 @@ const PublishOptions = () => {
         label={t('story')}
         isSelected={false}
         onClick={() => changePost('story')}
-        iconSrc={storyWhiteSVG}
+        iconSrc={activeTheme === 'light' ? storyWhiteSVG : storyDarkSVG}
         altText={t('story')}
       />
       <OptionButton
         label={t('event')}
         isSelected={false}
         onClick={() => changePost('event')}
-        iconSrc={eventsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? eventsWhiteSVG : eventsDarkSVG}
         altText={t('event')}
       />
       <OptionButton
         label={t('product')}
         isSelected={false}
         onClick={() => changePost('product')}
-        iconSrc={productsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? productsWhiteSVG : productsDarkSVG}
         altText={t('product')}
       />
       <OptionButton
         label={t('short')}
         isSelected={false}
         onClick={() => changePost('short')}
-        iconSrc={shortsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? shortsWhiteSVG : shortsDarkSVG}
         altText={t('short')}
       />
       <OptionButton
         label={t('video')}
         isSelected={false}
         onClick={() => changePost('video')}
-        iconSrc={videosWhiteSVG}
+        iconSrc={activeTheme === 'light' ? videosWhiteSVG : videosDarkSVG}
         altText={t('video')}
       />
       <OptionButton
         label={t('audio')}
         isSelected={false}
         onClick={() => changePost('audio')}
-        iconSrc={audioWhiteSVG}
+        iconSrc={activeTheme === 'light' ? audioWhiteSVG : audioDarkSVG}
         altText={t('audio')}
       />
       <OptionButton
         label={t('review')}
         isSelected={false}
         onClick={() => changePost('review')}
-        iconSrc={reviewsWhiteSVG}
+        iconSrc={activeTheme === 'light' ? reviewsWhiteSVG : reviewsDarkSVG}
         altText={t('review')}
       />
     </section>


### PR DESCRIPTION
## Summary
- select dark or light SVG icons in publish options based on active theme
- add theme-aware icons for manage options panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68966ed51e388327b470c5209995d1f8