### PR TITLE
feat: add hashtags and description to stories

### DIFF
--- a/src/modules/publications/add-post/components/forms/story-form.tsx
+++ b/src/modules/publications/add-post/components/forms/story-form.tsx
@@ -60,6 +60,17 @@ export default function StoryForm() {
           }}
           accept='image/*'
         />
+        <textarea
+          name='description'
+          placeholder='Description'
+          className='border rounded p-2'
+        />
+        <input
+          type='text'
+          name='hashtags'
+          placeholder='#hashtags'
+          className='border rounded p-2'
+        />
         <SubmitButton isPending={isPending} />
       </form>
     </CardWrapper>


### PR DESCRIPTION
## Summary
- allow story form to submit description and hashtags
- persist uploaded story images with user, description, and hashtags

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966fb91a4c8327947367416d5f5457