### PR TITLE
feat: enable profile updates

### DIFF
--- a/prisma/migrations/20250101000000_add_nickname_phone_number/migration.sql
+++ b/prisma/migrations/20250101000000_add_nickname_phone_number/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "nickname" TEXT,
+    ADD COLUMN "phoneNumber" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model ResetPasswordToken {
 model User {
   id            String       @id @default(cuid())
   name          String?
+  nickname      String?
   email         String       @unique
   emailVerified DateTime?
   image         String?
@@ -71,6 +72,7 @@ model User {
   role          userRole     @default(USER)
   accounts      Account[]
   photos        Photo[]
+  phoneNumber   String?
   phonePrefixId String?
   phonePrefix   PhonePrefix? @relation(fields: [phonePrefixId], references: [id])
   genderId      String?

--- a/src/modules/configuration/profile-update/actions/user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-profile-action.ts
@@ -1,3 +1,89 @@
 'use server'
 
-export default async function profileAction() {}
+// Auth
+import { auth } from '@/lib/auth/auth'
+
+// Database
+import { db } from '@/lib/orm/prisma-client'
+
+// Utils
+import { BackendProfileSchema } from '@/modules/configuration/profile-update/schemas'
+import { getUserById } from '@/data/users/get-user'
+import bcrypt from 'bcryptjs'
+
+export default async function profileAction(values: Record<string, any>) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { error: 'Unauthorized' }
+  }
+
+  const parsed = BackendProfileSchema.safeParse(values)
+  if (!parsed.success) {
+    return { error: 'Invalid fields' }
+  }
+
+  const data = parsed.data
+  try {
+    const user = await getUserById(session.user.id)
+    if (!user) {
+      return { error: 'User not found' }
+    }
+
+    const updateData: any = {}
+
+    if (data.name) updateData.name = data.name
+    if (data.nickname) updateData.nickname = data.nickname
+    if (data.birthdate) updateData.birthdate = new Date(data.birthdate)
+    if (data.zipCode) updateData.zipCode = data.zipCode
+    if (data.country) updateData.country = data.country
+    if (data.city) updateData.city = data.city
+    if (data.address) updateData.address = data.address
+    if (data.occupation) updateData.occupation = data.occupation
+    if (data.interests) updateData.interests = data.interests
+    if (data.slogan) updateData.slogan = data.slogan
+    if (data.portfolio) updateData.portfolioUrl = data.portfolio
+    if (data.phoneNumber) updateData.phoneNumber = data.phoneNumber
+    if (data.email) updateData.email = data.email
+
+    if (data.gender) {
+      const gender = await db.genders.findFirst({
+        where: { name: data.gender }
+      })
+      if (gender) updateData.genderId = gender.id
+    }
+
+    if (data.phonePrefix) {
+      const prefix = await db.phonePrefix.findUnique({
+        where: { prefix: data.phonePrefix }
+      })
+      if (prefix) updateData.phonePrefixId = prefix.id
+    }
+
+    if (data.newPassword) {
+      if (!user.password) {
+        return { error: 'OAuth accounts cannot change password' }
+      }
+      if (!data.password) {
+        return { error: 'Current password required' }
+      }
+      const validPassword = await bcrypt.compare(data.password, user.password)
+      if (!validPassword) {
+        return { error: 'Incorrect password' }
+      }
+      updateData.password = await bcrypt.hash(data.newPassword, 10)
+    }
+
+    await db.user.update({
+      where: { id: user.id },
+      data: updateData
+    })
+
+    return { success: 'Profile updated' }
+  } catch (error) {
+    console.error('Error updating profile:', error)
+    return { error: 'Update failed' }
+  } finally {
+    await db.$disconnect()
+  }
+}
+

--- a/src/modules/configuration/profile-update/components/inputs/phone-number-input.tsx
+++ b/src/modules/configuration/profile-update/components/inputs/phone-number-input.tsx
@@ -30,7 +30,7 @@ const PhoneNumberInput = ({ name, isPending }: PhoneNumberInputProps) => {
   const { session, hydrated } = useUserSession()
   const [userPhoneNumber, setuserPhoneNumber] = useState<string | undefined>('')
   useEffect(() => {
-    if (hydrated) setuserPhoneNumber(session?.user?.number || '')
+    if (hydrated) setuserPhoneNumber(session?.user?.phoneNumber || '')
   }, [hydrated, session, t])
   return (
     <FormField

--- a/src/modules/configuration/profile-update/hooks/useSettingsForm.tsx
+++ b/src/modules/configuration/profile-update/hooks/useSettingsForm.tsx
@@ -4,6 +4,9 @@
 import { useEffect, useState, useTransition } from 'react'
 import { useForm } from 'react-hook-form'
 
+// Actions
+import profileAction from '@/modules/configuration/profile-update/actions/user-profile-action'
+
 export function useSettingsForm() {
   // States
   const [error, setError] = useState<string | undefined>('')
@@ -38,9 +41,11 @@ export function useSettingsForm() {
   const onSubmit = (values: Record<string, any>) => {
     setError('')
     setSuccess('')
-    console.log('Submitted Values:', values)
     startTransition(() => {
-      console.log('Start transition')
+      profileAction(values).then((data) => {
+        if (data?.error) setError(data.error)
+        if (data?.success) setSuccess(data.success)
+      })
     })
   }
 

--- a/src/modules/configuration/profile-update/schemas/index.ts
+++ b/src/modules/configuration/profile-update/schemas/index.ts
@@ -79,12 +79,7 @@ export const FrontendProfileSchema = (t: (key: string) => string) =>
       .string()
       .max(64, { message: t('maxLength') })
       .optional(),
-    interests: z
-      .array(z.string().max(64))
-      .optional()
-      .refine((interests) => !interests || interests.length <= 10, {
-        message: t('tooManyInterests')
-      }),
+    interests: z.string().max(64).optional(),
     slogan: z
       .string()
       .max(64, { message: t('maxLength') })
@@ -146,10 +141,7 @@ export const BackendProfileSchema = z.object({
   city: z.string().max(64).optional(),
   address: z.string().max(128).optional(),
   occupation: z.string().max(64).optional(),
-  interests: z
-    .array(z.string().max(64))
-    .optional()
-    .refine((interests) => !interests || interests.length <= 10),
+  interests: z.string().max(64).optional(),
   slogan: z.string().max(64).optional(),
   portfolio: z.string().url().max(128).optional()
 })


### PR DESCRIPTION
## Summary
- allow saving profile information from settings panel
- store nickname and phone number in the user model
- validate and persist profile changes including password updates with OAuth check

## Testing
- `npx prisma generate`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689677bfc95883279a1861c0eaf04e0a