### PR TITLE
feat: add story interactions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,10 +46,54 @@ model Photo {
   hashtags     String[]
   userId       String
   createdAt    DateTime @default(now())
+  shareCount   Int      @default(0)
+
+  likes      PhotoLike[]
+  comments   PhotoComment[]
+  favorites  PhotoFavorite[]
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+model PhotoLike {
+  id      String @id @default(cuid())
+  photoId String
+  userId  String
+  createdAt DateTime @default(now())
+
+  photo Photo @relation(fields: [photoId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([photoId, userId])
+  @@index([photoId])
+}
+
+model PhotoComment {
+  id      String @id @default(cuid())
+  photoId String
+  userId  String
+  content String
+  createdAt DateTime @default(now())
+
+  photo Photo @relation(fields: [photoId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([photoId])
+}
+
+model PhotoFavorite {
+  id      String @id @default(cuid())
+  photoId String
+  userId  String
+  createdAt DateTime @default(now())
+
+  photo Photo @relation(fields: [photoId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([photoId, userId])
+  @@index([photoId])
 }
 
 model ResetPasswordToken {
@@ -72,6 +116,9 @@ model User {
   role          userRole     @default(USER)
   accounts      Account[]
   photos        Photo[]
+  likes         PhotoLike[]
+  comments      PhotoComment[]
+  favorites     PhotoFavorite[]
   phoneNumber   String?
   phonePrefixId String?
   phonePrefix   PhonePrefix? @relation(fields: [phonePrefixId], references: [id])

--- a/src/app/api/stories/[id]/comment/route.ts
+++ b/src/app/api/stories/[id]/comment/route.ts
@@ -1,0 +1,23 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { content } = await request.json()
+  if (!content || typeof content !== 'string')
+    return NextResponse.json({ error: 'Content required' }, { status: 400 })
+
+  const comment = await db.photoComment.create({
+    data: { photoId: params.id, userId: session.user.id, content }
+  })
+
+  return NextResponse.json({ comment })
+}

--- a/src/app/api/stories/[id]/favorite/route.ts
+++ b/src/app/api/stories/[id]/favorite/route.ts
@@ -1,0 +1,28 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function POST(_request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const photoId = params.id
+  const userId = session.user.id
+
+  const existing = await db.photoFavorite.findUnique({
+    where: { photoId_userId: { photoId, userId } }
+  })
+
+  if (existing) {
+    await db.photoFavorite.delete({ where: { id: existing.id } })
+    return NextResponse.json({ favorite: false })
+  }
+
+  await db.photoFavorite.create({ data: { photoId, userId } })
+  return NextResponse.json({ favorite: true })
+}

--- a/src/app/api/stories/[id]/like/route.ts
+++ b/src/app/api/stories/[id]/like/route.ts
@@ -1,0 +1,28 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function POST(_request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const photoId = params.id
+  const userId = session.user.id
+
+  const existing = await db.photoLike.findUnique({
+    where: { photoId_userId: { photoId, userId } }
+  })
+
+  if (existing) {
+    await db.photoLike.delete({ where: { id: existing.id } })
+    return NextResponse.json({ liked: false })
+  }
+
+  await db.photoLike.create({ data: { photoId, userId } })
+  return NextResponse.json({ liked: true })
+}

--- a/src/app/api/stories/[id]/route.ts
+++ b/src/app/api/stories/[id]/route.ts
@@ -1,0 +1,49 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: {
+    id: string
+  }
+}
+
+export async function PATCH(request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const photo = await db.photo.findUnique({ where: { id: params.id } })
+  if (!photo)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (photo.userId !== session.user.id)
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const { title, description, hashtags } = await request.json()
+
+  const updated = await db.photo.update({
+    where: { id: params.id },
+    data: {
+      title: title ?? photo.title,
+      description: description ?? photo.description,
+      hashtags: Array.isArray(hashtags) ? hashtags : photo.hashtags
+    }
+  })
+
+  return NextResponse.json({ photo: updated })
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const photo = await db.photo.findUnique({ where: { id: params.id } })
+  if (!photo)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (photo.userId !== session.user.id)
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  await db.photo.delete({ where: { id: params.id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/stories/[id]/share/route.ts
+++ b/src/app/api/stories/[id]/share/route.ts
@@ -1,0 +1,21 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function POST(_request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const photo = await db.photo.update({
+    where: { id: params.id },
+    data: { shareCount: { increment: 1 } },
+    select: { shareCount: true }
+  })
+
+  return NextResponse.json({ shareCount: photo.shareCount })
+}


### PR DESCRIPTION
## Summary
- add interaction models for photos with likes, comments, favorites and share count
- implement API routes to like, comment, favorite, share, update and delete stories

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689680174284832790ca1247f90dfd3c