### PR TITLE
feat(settings): load user profile in settings page

### DIFF
--- a/src/modules/configuration/profile-update/actions/get-user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/get-user-profile-action.ts
@@ -1,0 +1,52 @@
+'use server'
+
+// Auth
+import { auth } from '@/lib/auth/auth'
+
+// Database
+import { db } from '@/lib/orm/prisma-client'
+
+export default async function getUserProfileAction () {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return null
+  }
+
+  try {
+    const user = await db.user.findUnique({
+      where: { id: session.user.id },
+      include: {
+        gender: true,
+        phonePrefix: true
+      }
+    })
+
+    if (!user) return null
+
+    return {
+      name: user.name || '',
+      nickname: user.nickname || '',
+      gender: user.gender?.name || '',
+      birthdate: user.birthdate
+        ? user.birthdate.toISOString().split('T')[0]
+        : '',
+      phonePrefix: user.phonePrefix?.prefix || '',
+      phoneNumber: user.phoneNumber || '',
+      email: user.email || '',
+      zipCode: user.zipCode || '',
+      country: user.country || '',
+      city: user.city || '',
+      address: user.address || '',
+      occupation: user.occupation || '',
+      interests: user.interests || '',
+      slogan: user.slogan || '',
+      portfolio: user.portfolioUrl || ''
+    }
+  } catch (error) {
+    console.error('Error fetching profile:', error)
+    return null
+  } finally {
+    await db.$disconnect()
+  }
+}
+

--- a/src/modules/configuration/profile-update/hooks/useSettingsForm.tsx
+++ b/src/modules/configuration/profile-update/hooks/useSettingsForm.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form'
 
 // Actions
 import profileAction from '@/modules/configuration/profile-update/actions/user-profile-action'
+import getUserProfileAction from '@/modules/configuration/profile-update/actions/get-user-profile-action'
 
 export function useSettingsForm() {
   // States
@@ -50,7 +51,18 @@ export function useSettingsForm() {
   }
 
   // Effects
-  useEffect(() => setHydrated(true), [])
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getUserProfileAction()
+        if (data) form.reset(data)
+      } catch (error) {
+        console.error('Error fetching profile:', error)
+      } finally {
+        setHydrated(true)
+      }
+    })()
+  }, [form])
 
   return {
     form,


### PR DESCRIPTION
## Summary
- add server action to fetch current user's profile data
- populate settings form with stored profile info on mount

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68968c0a9e208327947bda6e8ace29a3