### PR TITLE
Show 0 instead of random counts for photo buttons

### DIFF
--- a/src/app/api/stories/route.ts
+++ b/src/app/api/stories/route.ts
@@ -22,7 +22,12 @@ export async function GET(request: Request) {
 
   const photos = await db.photo.findMany({
     orderBy: { createdAt: 'desc' },
-    take: limit
+    take: limit,
+    include: {
+      _count: {
+        select: { likes: true, comments: true, favorites: true }
+      }
+    }
   })
 
   return NextResponse.json({ photos })

--- a/src/modules/publications/show-post/components/posts/show-post-images.tsx
+++ b/src/modules/publications/show-post/components/posts/show-post-images.tsx
@@ -89,22 +89,22 @@ export default function ShowPostImages() {
             <PostButton
               iconAlt='Like icon'
               iconDisplay='like'
-              textDisplay={randomUtils.getRandomLikes().toString()}
+              textDisplay={(photo._count?.likes ?? 0).toString()}
             />
             <PostButton
               iconAlt='Comment icon'
               iconDisplay='comments'
-              textDisplay={randomUtils.getRandomInteractions().toString()}
+              textDisplay={(photo._count?.comments ?? 0).toString()}
             />
             <PostButton
               iconAlt='Save icon'
               iconDisplay='save'
-              textDisplay={randomUtils.getRandomInteractions().toString()}
+              textDisplay={(photo._count?.favorites ?? 0).toString()}
             />
             <PostButton
               iconAlt='Share icon'
               iconDisplay='share'
-              textDisplay={randomUtils.getRandomInteractions().toString()}
+              textDisplay={(photo.shareCount ?? 0).toString()}
             />
             <PostButton iconAlt='Options icon' iconDisplay='options' />
           </aside>

--- a/src/modules/publications/show-post/hooks/useFetchLatestPhotos.tsx
+++ b/src/modules/publications/show-post/hooks/useFetchLatestPhotos.tsx
@@ -10,6 +10,12 @@ interface Photo {
   photographer: string
   hashtags: string[]
   createdAt: string
+  shareCount: number
+  _count: {
+    likes: number
+    comments: number
+    favorites: number
+  }
 }
 
 export const useFetchLatestPhotos = (limit = 10) => {


### PR DESCRIPTION
## Summary
- include like, comment and favorite counts in `/api/stories` response
- expose counts in `useFetchLatestPhotos` hook
- display database counts on image post buttons, defaulting to 0 when none

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Shadows Into Light`)*

------
https://chatgpt.com/codex/tasks/task_e_68968b396e088327a073a6018eca7a85