### PR TITLE
fix profile update field validation

### DIFF
--- a/src/modules/configuration/profile-update/actions/user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-profile-action.ts
@@ -16,8 +16,11 @@ export default async function profileAction(values: Record<string, any>) {
   if (!session?.user?.id) {
     return { error: 'Unauthorized' }
   }
+  const filteredValues = Object.fromEntries(
+    Object.entries(values).filter(([, v]) => v !== '' && v !== undefined && v !== null)
+  )
 
-  const parsed = BackendProfileSchema.safeParse(values)
+  const parsed = BackendProfileSchema.safeParse(filteredValues)
   if (!parsed.success) {
     return { error: 'Invalid fields' }
   }


### PR DESCRIPTION
## Summary
- ignore empty profile fields before schema validation to prevent erroneous `Invalid fields` errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896fafb686c8327a16fa397ca80636f