### PR TITLE
Format member since date on profile

### DIFF
--- a/src/modules/auth/session-data/components/user-article.tsx
+++ b/src/modules/auth/session-data/components/user-article.tsx
@@ -22,7 +22,10 @@ const UserArticle = () => {
       setFollowers(session?.user?.followers || 0)
       setFollowing(session?.user?.following || 0)
       setPosts(session?.user?.posts || 0)
-      setMemberSince(session?.user?.createdAt || null)
+      const createdAt = session?.user?.createdAt
+      setMemberSince(
+        createdAt ? new Date(createdAt).toISOString().split('T')[0] : null
+      )
     }
   }, [hydrated, session])
 


### PR DESCRIPTION
## Summary
- Format user profile's `member since` to show registration date in YYYY-MM-DD

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896ff956aac8327809d8566eb72a736