### PR TITLE
Expose user creation date for profile displays

### DIFF
--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -11,6 +11,7 @@ declare module 'next-auth' {
       followers: number
       following: number
       posts: number
+      createdAt: string
     } & DefaultSession['user']
   }
   // Roles allowed in users
@@ -19,6 +20,7 @@ declare module 'next-auth' {
     followers: number
     following: number
     posts: number
+    createdAt: Date
   }
 }
 
@@ -29,6 +31,7 @@ declare module 'next-auth/jwt' {
     followers?: number
     following?: number
     posts?: number
+    createdAt?: string
   }
 }
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -71,6 +71,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         if (typeof token.following === 'number')
           session.user.following = token.following
         if (typeof token.posts === 'number') session.user.posts = token.posts
+        if (token.createdAt) session.user.createdAt = token.createdAt as string
       }
 
       // Return the updated session
@@ -96,6 +97,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       token.followers = existingUser.followers
       token.following = existingUser.following
       token.posts = existingUser.posts
+      token.createdAt = existingUser.createdAt.toISOString()
 
       // Return the updated token
       return token


### PR DESCRIPTION
## Summary
- Include user creation date in JWT and session objects
- Declare `createdAt` fields in NextAuth types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Error: Failed to fetch font)*

------
https://chatgpt.com/codex/tasks/task_e_6897052b148483279b7804defbbb5d31