### PR TITLE
feat: add location to stories

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -102,6 +102,7 @@
       "select": "Select",
       "slogan": "Slogan",
       "address": "Address",
+      "location": "Location",
       "number": "No.",
       "username": "Username",
       "zipCode": "Zip code",

--- a/messages/es.json
+++ b/messages/es.json
@@ -101,6 +101,7 @@
       "select": "Seleccionar",
       "slogan": "Eslogan",
       "address": "Dirección",
+      "location": "Ubicación",
       "number": "N.º",
       "username": "Nombre de usuario",
       "zipCode": "Código postal",

--- a/prisma/migrations/20250808234000_add_photo_location/migration.sql
+++ b/prisma/migrations/20250808234000_add_photo_location/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Photo" ADD COLUMN     "location" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Photo {
   imageUrl     String
   photographer String
   hashtags     String[]
+  location     String?
   userId       String
   createdAt    DateTime @default(now())
   shareCount   Int      @default(0)

--- a/src/app/api/stories/[id]/route.ts
+++ b/src/app/api/stories/[id]/route.ts
@@ -19,14 +19,15 @@ export async function PATCH(request: Request, { params }: Params) {
   if (photo.userId !== session.user.id)
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
-  const { title, description, hashtags } = await request.json()
+  const { title, description, hashtags, location } = await request.json()
 
   const updated = await db.photo.update({
     where: { id: params.id },
     data: {
       title: title ?? photo.title,
       description: description ?? photo.description,
-      hashtags: Array.isArray(hashtags) ? hashtags : photo.hashtags
+      hashtags: Array.isArray(hashtags) ? hashtags : photo.hashtags,
+      location: location ?? photo.location
     }
   })
 

--- a/src/app/api/stories/route.ts
+++ b/src/app/api/stories/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: Request) {
   // Get the file from the form data
   const file = formData.get('file')
   const description = formData.get('description') as string | null
+  const location = formData.get('location') as string | null
   const hashtagsRaw = formData.get('hashtags') as string | null
 
   // Check if a file was uploaded
@@ -95,6 +96,7 @@ export async function POST(request: Request) {
       imageUrl: response.secure_url,
       photographer: session.user.name || 'Unknown',
       hashtags,
+      location: location || undefined,
       userId: session.user.id
     }
   })

--- a/src/modules/publications/add-post/components/forms/story-form.tsx
+++ b/src/modules/publications/add-post/components/forms/story-form.tsx
@@ -19,6 +19,7 @@ export default function StoryForm() {
   const [hashtagsValues, setHashtagsValues] = useState<string[]>([])
   // Translations
   const t = useTranslations('FeedForms')
+  const tForms = useTranslations('Forms')
   // Transition state
   const [isPending, startTransition] = useTransition()
 
@@ -65,6 +66,12 @@ export default function StoryForm() {
         <textarea
           name='description'
           placeholder='Description'
+          className='border rounded p-2'
+        />
+        <input
+          type='text'
+          name='location'
+          placeholder={tForms('inputs.location')}
           className='border rounded p-2'
         />
         <input

--- a/src/modules/publications/show-post/components/posts/show-post-images.tsx
+++ b/src/modules/publications/show-post/components/posts/show-post-images.tsx
@@ -87,7 +87,7 @@ export default function ShowPostImages() {
               intereses={randomUtils.getRandomInterests()}
               slogan={randomUtils.getRandomSlogan()}
               date={randomUtils.getRandomTime()}
-              location={randomUtils.getRandomCapital()}
+              location={photo.location || randomUtils.getRandomCapital()}
               trending={randomUtils.getRandomBoolean()}
               followers={randomUtils.getRandomFollowers()}
               reliable={randomUtils.getRandomBoolean()}

--- a/src/modules/publications/show-post/hooks/useFetchLatestPhotos.tsx
+++ b/src/modules/publications/show-post/hooks/useFetchLatestPhotos.tsx
@@ -9,6 +9,7 @@ interface Photo {
   imageUrl: string
   photographer: string
   hashtags: string[]
+  location?: string | null
   createdAt: string
   shareCount: number
   liked: boolean


### PR DESCRIPTION
## Summary
- allow specifying location when creating stories, including translations and form field
- persist location in stories API and database schema
- expose saved location in story feed and allow updates via PATCH

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897094a05408327a73ae7969c2d8246