### PR TITLE
feat: set profile input text size to 14

### DIFF
--- a/src/modules/configuration/profile-update/components/forms/profile-form.tsx
+++ b/src/modules/configuration/profile-update/components/forms/profile-form.tsx
@@ -58,7 +58,7 @@ export default function SettingsForm() {
     <CardWrapper>
       <FormProvider {...form}>
         <Form {...form}>
-          <form className='space-y-8' onSubmit={form.handleSubmit(onSubmit)}>
+          <form className='space-y-8 text-sm' onSubmit={form.handleSubmit(onSubmit)}>
 
             <div className='space-y-8 mt-8'>
               <FormFieldset legend={f('identity')}>


### PR DESCRIPTION
## Summary
- ensure profile page inputs display at 14px by inheriting `text-sm`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971144e13c8327b3df6d6defefcda7