### PR TITLE
feat: add shorts CRUD and display

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,9 +49,9 @@ model Photo {
   createdAt    DateTime @default(now())
   shareCount   Int      @default(0)
 
-  likes      PhotoLike[]
-  comments   PhotoComment[]
-  favorites  PhotoFavorite[]
+  likes     PhotoLike[]
+  comments  PhotoComment[]
+  favorites PhotoFavorite[]
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -59,9 +59,9 @@ model Photo {
 }
 
 model PhotoLike {
-  id      String @id @default(cuid())
-  photoId String
-  userId  String
+  id        String   @id @default(cuid())
+  photoId   String
+  userId    String
   createdAt DateTime @default(now())
 
   photo Photo @relation(fields: [photoId], references: [id], onDelete: Cascade)
@@ -72,10 +72,10 @@ model PhotoLike {
 }
 
 model PhotoComment {
-  id      String @id @default(cuid())
-  photoId String
-  userId  String
-  content String
+  id        String   @id @default(cuid())
+  photoId   String
+  userId    String
+  content   String
   createdAt DateTime @default(now())
 
   photo Photo @relation(fields: [photoId], references: [id], onDelete: Cascade)
@@ -85,9 +85,9 @@ model PhotoComment {
 }
 
 model PhotoFavorite {
-  id      String @id @default(cuid())
-  photoId String
-  userId  String
+  id        String   @id @default(cuid())
+  photoId   String
+  userId    String
   createdAt DateTime @default(now())
 
   photo Photo @relation(fields: [photoId], references: [id], onDelete: Cascade)
@@ -95,6 +95,48 @@ model PhotoFavorite {
 
   @@unique([photoId, userId])
   @@index([photoId])
+}
+
+model Short {
+  id          String   @id @default(cuid())
+  title       String
+  description String?
+  videoUrl    String
+  userId      String
+  createdAt   DateTime @default(now())
+
+  likes    ShortLike[]
+  comments ShortComment[]
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model ShortLike {
+  id        String   @id @default(cuid())
+  shortId   String
+  userId    String
+  createdAt DateTime @default(now())
+
+  short Short @relation(fields: [shortId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([shortId, userId])
+  @@index([shortId])
+}
+
+model ShortComment {
+  id        String   @id @default(cuid())
+  shortId   String
+  userId    String
+  content   String
+  createdAt DateTime @default(now())
+
+  short Short @relation(fields: [shortId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([shortId])
 }
 
 model ResetPasswordToken {
@@ -107,24 +149,27 @@ model ResetPasswordToken {
 }
 
 model User {
-  id            String       @id @default(cuid())
+  id            String          @id @default(cuid())
   name          String?
   nickname      String?
-  email         String       @unique
+  email         String          @unique
   emailVerified DateTime?
   image         String?
   password      String?
-  role          userRole     @default(USER)
+  role          userRole        @default(USER)
   accounts      Account[]
   photos        Photo[]
   likes         PhotoLike[]
   comments      PhotoComment[]
   favorites     PhotoFavorite[]
+  shorts        Short[]
+  shortLikes    ShortLike[]
+  shortComments ShortComment[]
   phoneNumber   String?
   phonePrefixId String?
-  phonePrefix   PhonePrefix? @relation(fields: [phonePrefixId], references: [id])
+  phonePrefix   PhonePrefix?    @relation(fields: [phonePrefixId], references: [id])
   genderId      String?
-  gender        Genders?     @relation(fields: [genderId], references: [id])
+  gender        Genders?        @relation(fields: [genderId], references: [id])
   birthdate     DateTime?
   country       String?
   city          String?
@@ -134,11 +179,11 @@ model User {
   interests     String?
   slogan        String?
   portfolioUrl  String?
-  followers     Int         @default(0)
-  following     Int         @default(0)
-  posts         Int         @default(0)
-  createdAt     DateTime     @default(now())
-  updatedAt     DateTime     @updatedAt
+  followers     Int             @default(0)
+  following     Int             @default(0)
+  posts         Int             @default(0)
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
 }
 
 model VerificationToken {

--- a/src/app/[locale]/(features)/(feeds)/shorts/page.tsx
+++ b/src/app/[locale]/(features)/(feeds)/shorts/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+// Components
+import ShowPostShorts from '@/modules/publications/show-post/components/posts/show-post-shorts'
+
+// Styles
+import '@/styles/globals.css'
+
+export default function ShortsPage() {
+  return (
+    <>
+      <ShowPostShorts />
+      <div className='sm:grid md:hidden place-content-center w-full h-full'>
+        <h1 className='w-fit m-auto'>
+          🚧 Mobile version coming soon!
+          <br />
+          🚧 ¡Versión para móviles próximamente!
+        </h1>
+      </div>
+    </>
+  )
+}
+

--- a/src/app/api/shorts/[id]/comment/route.ts
+++ b/src/app/api/shorts/[id]/comment/route.ts
@@ -1,0 +1,24 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { content } = await request.json()
+  if (!content || typeof content !== 'string')
+    return NextResponse.json({ error: 'Content required' }, { status: 400 })
+
+  const comment = await db.shortComment.create({
+    data: { shortId: params.id, userId: session.user.id, content }
+  })
+
+  return NextResponse.json({ comment })
+}
+

--- a/src/app/api/shorts/[id]/like/route.ts
+++ b/src/app/api/shorts/[id]/like/route.ts
@@ -1,0 +1,29 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function POST(_request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const shortId = params.id
+  const userId = session.user.id
+
+  const existing = await db.shortLike.findUnique({
+    where: { shortId_userId: { shortId, userId } }
+  })
+
+  if (existing) {
+    await db.shortLike.delete({ where: { id: existing.id } })
+    return NextResponse.json({ liked: false })
+  }
+
+  await db.shortLike.create({ data: { shortId, userId } })
+  return NextResponse.json({ liked: true })
+}
+

--- a/src/app/api/shorts/[id]/route.ts
+++ b/src/app/api/shorts/[id]/route.ts
@@ -1,0 +1,49 @@
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+import { NextResponse } from 'next/server'
+
+interface Params {
+  params: {
+    id: string
+  }
+}
+
+export async function PATCH(request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const short = await db.short.findUnique({ where: { id: params.id } })
+  if (!short)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (short.userId !== session.user.id)
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const { title, description } = await request.json()
+
+  const updated = await db.short.update({
+    where: { id: params.id },
+    data: {
+      title: title ?? short.title,
+      description: description ?? short.description
+    }
+  })
+
+  return NextResponse.json({ short: updated })
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const short = await db.short.findUnique({ where: { id: params.id } })
+  if (!short)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (short.userId !== session.user.id)
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  await db.short.delete({ where: { id: params.id } })
+  return NextResponse.json({ success: true })
+}
+

--- a/src/app/api/shorts/route.ts
+++ b/src/app/api/shorts/route.ts
@@ -1,0 +1,101 @@
+'use server'
+
+// Cloudinary
+import { v2 as cloudinary } from 'cloudinary'
+import { db } from '@/lib/orm/prisma-client'
+import { auth } from '@/lib/auth/auth'
+
+// Response
+import { NextResponse } from 'next/server'
+
+// Configuration
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_API_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+})
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const limitParam = searchParams.get('limit')
+  const limit = limitParam ? parseInt(limitParam, 10) : 10
+
+  const session = await auth()
+  const userId = session?.user?.id
+
+  const shorts = await db.short.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    include: {
+      _count: { select: { likes: true, comments: true } },
+      ...(userId
+        ? { likes: { where: { userId }, select: { id: true } } }
+        : {})
+    }
+  })
+
+  const formatted = shorts.map((short: any) => {
+    const { likes = [], ...rest } = short
+    const liked = userId ? likes.length > 0 : false
+    return { ...rest, liked }
+  })
+
+  return NextResponse.json({ shorts: formatted })
+}
+
+export async function POST(request: Request) {
+  const formData = await request.formData()
+  const file = formData.get('file')
+  const description = formData.get('description') as string | null
+  const title = formData.get('title') as string | null
+
+  if (!file || !(file instanceof Blob))
+    return NextResponse.json({ error: 'No file uploaded' }, { status: 400 })
+
+  const bytes = await file.arrayBuffer()
+  const buffer = Buffer.from(bytes)
+
+  const response = await new Promise<any>((resolve, reject) => {
+    cloudinary.uploader
+      .upload_stream(
+        { resource_type: 'video', folder: 'shorts' },
+        (error, result) => {
+          if (error) reject(error)
+          resolve(result)
+        }
+      )
+      .end(buffer)
+  })
+
+  if (response.duration && response.duration > 60) {
+    if (response.public_id) {
+      await cloudinary.uploader.destroy(response.public_id, {
+        resource_type: 'video'
+      })
+    }
+    return NextResponse.json(
+      { error: 'Video exceeds 60 seconds limit' },
+      { status: 400 }
+    )
+  }
+
+  const session = await auth()
+  if (!session?.user?.id)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const short = await db.short.create({
+    data: {
+      title: title || 'Short',
+      description: description || undefined,
+      videoUrl: response.secure_url,
+      userId: session.user.id
+    }
+  })
+
+  return NextResponse.json({
+    message: 'File uploaded successfully',
+    url: response.secure_url,
+    short
+  })
+}
+

--- a/src/modules/publications/show-post/components/posts/show-post-shorts.tsx
+++ b/src/modules/publications/show-post/components/posts/show-post-shorts.tsx
@@ -1,0 +1,88 @@
+// Components
+import PostButton from '@/modules/publications/show-post/components/buttons/post-button'
+import NoContent from '@/modules/publications/show-post/components/alerts/stock-empty'
+
+// Custom
+import {
+  useFetchLatestShorts,
+  type Short
+} from '@/modules/publications/show-post/hooks/useFetchLatestShorts'
+import { useState, useEffect } from 'react'
+
+export default function ShowPostShorts() {
+  const { shorts: initialShorts, loading } = useFetchLatestShorts(10)
+  const [shorts, setShorts] = useState<Short[]>([])
+
+  useEffect(() => {
+    setShorts(initialShorts)
+  }, [initialShorts])
+
+  const handleLike = async (shortId: string) => {
+    try {
+      const res = await fetch(`/api/shorts/${shortId}/like`, { method: 'POST' })
+      if (!res.ok) return
+      const data = await res.json()
+      setShorts((prev) =>
+        prev.map((short) =>
+          short.id === shortId
+            ? {
+                ...short,
+                liked: data.liked,
+                _count: {
+                  ...short._count,
+                  likes: short._count.likes + (data.liked ? 1 : -1)
+                }
+              }
+            : short
+        )
+      )
+    } catch (error) {
+      console.error('Error liking short', error)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className='w-full h-full flex justify-center items-center'>
+        <h2 className='text-center text-gray-500'>{''}</h2>
+      </div>
+    )
+  }
+
+  if (!shorts || shorts.length === 0)
+    return <NoContent text={'No shorts available'} />
+
+  return (
+    <div className='w-full h-fit flex flex-col justify-center items-center gap-16'>
+      {shorts.map((short: Short) => (
+        <article
+          key={short.id}
+          className='relative h-fit flex flex-col gap-4 items-center'
+        >
+          <section className='w-60 h-96 overflow-hidden rounded-3xl'>
+            <video
+              src={short.videoUrl}
+              controls
+              className='rounded-3xl drop-shadow-sm object-cover w-full h-full'
+            />
+          </section>
+          <aside className='w-full h-full flex flex-row gap-2 justify-center items-center'>
+            <PostButton
+              iconAlt='Like icon'
+              iconDisplay='like'
+              textDisplay={(short._count?.likes ?? 0).toString()}
+              onClick={() => handleLike(short.id)}
+              isActive={short.liked}
+            />
+            <PostButton
+              iconAlt='Comment icon'
+              iconDisplay='comments'
+              textDisplay={(short._count?.comments ?? 0).toString()}
+            />
+          </aside>
+        </article>
+      ))}
+    </div>
+  )
+}
+

--- a/src/modules/publications/show-post/hooks/useFetchLatestShorts.tsx
+++ b/src/modules/publications/show-post/hooks/useFetchLatestShorts.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Short {
+  id: string
+  title: string
+  description?: string | null
+  videoUrl: string
+  createdAt: string
+  liked: boolean
+  _count: {
+    likes: number
+    comments: number
+  }
+}
+
+export const useFetchLatestShorts = (limit = 10) => {
+  const [shorts, setShorts] = useState<Short[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchShorts = async () => {
+      try {
+        const res = await fetch(`/api/shorts?limit=${limit}`)
+        if (!res.ok) throw new Error('Failed to fetch shorts')
+        const data = await res.json()
+        setShorts(
+          data.shorts.map((short: any) => ({
+            ...short,
+            liked: Boolean(short.liked)
+          }))
+        )
+      } catch (err: any) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchShorts()
+  }, [limit])
+
+  return { shorts, loading, error }
+}
+
+export type { Short }
+


### PR DESCRIPTION
## Summary
- add Prisma models and API endpoints for video shorts with 60s limit
- render shorts feed with like and comment actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error: 'handleUpdate' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_689715c54be8832796f6e952f40faed3