### PR TITLE
fix: heart like button turns red when active

### DIFF
--- a/src/modules/publications/show-post/components/buttons/post-button.tsx
+++ b/src/modules/publications/show-post/components/buttons/post-button.tsx
@@ -42,7 +42,7 @@ export default function PostButton({
             className='drop-shadow-sm w-7 h-7'
             size={iconSize}
             aria-label={iconAlt}
-            color={isActive ? '#932D30' : iconColor}
+            style={{ color: isActive ? '#932D30' : iconColor }}
           />
         )}
         {iconDisplay === 'comments' && (


### PR DESCRIPTION
## Summary
- ensure heart like button displays red when liked by applying inline color style

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971b85ae2c8327bb92b9ce37f5365c