### PR TITLE
fix: ensure gender translations for male and female

### DIFF
--- a/src/modules/configuration/profile-update/components/inputs/gender-input.tsx
+++ b/src/modules/configuration/profile-update/components/inputs/gender-input.tsx
@@ -103,10 +103,10 @@ export default function GenderInput({ name, isPending }: GenderInputProps) {
               >
                 {capitalizeFirstWord(
                   t(
-                    `inputs.genders.${
+                    `inputs.genders.${(
                       genders.find((g) => g.id === userGender)?.name ||
                       'reserved'
-                    }`
+                    ).toLowerCase()}`
                   )
                 )}
               </button>
@@ -132,7 +132,9 @@ export default function GenderInput({ name, isPending }: GenderInputProps) {
                       }}
                       className='px-3 py-1 cursor-pointer hover:bg-[#EBEAEB] dark:hover:bg-[#3b3b40] rounded-none capitalized'
                     >
-                      {capitalizeFirstWord(t(`inputs.genders.${name}`))}
+                      {capitalizeFirstWord(
+                        t(`inputs.genders.${name.toLowerCase()}`)
+                      )}
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
## Summary
- normalize gender identifiers before lookup so male and female labels translate correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897216fda388327a918542b18d66a16