### PR TITLE
Handle empty shorts feed

### DIFF
--- a/src/modules/publications/show-post/components/posts/show-post-shorts.tsx
+++ b/src/modules/publications/show-post/components/posts/show-post-shorts.tsx
@@ -10,7 +10,7 @@ import {
 import { useState, useEffect } from 'react'
 
 export default function ShowPostShorts() {
-  const { shorts: initialShorts, loading } = useFetchLatestShorts(10)
+  const { shorts: initialShorts, loading, error } = useFetchLatestShorts(10)
   const [shorts, setShorts] = useState<Short[]>([])
 
   useEffect(() => {
@@ -49,7 +49,7 @@ export default function ShowPostShorts() {
     )
   }
 
-  if (!shorts || shorts.length === 0)
+  if (error || !shorts || shorts.length === 0)
     return <NoContent text={'No shorts available'} />
 
   return (

--- a/src/modules/publications/show-post/hooks/useFetchLatestShorts.tsx
+++ b/src/modules/publications/show-post/hooks/useFetchLatestShorts.tsx
@@ -26,12 +26,15 @@ export const useFetchLatestShorts = (limit = 10) => {
         const res = await fetch(`/api/shorts?limit=${limit}`)
         if (!res.ok) throw new Error('Failed to fetch shorts')
         const data = await res.json()
-        setShorts(
-          data.shorts.map((short: any) => ({
-            ...short,
-            liked: Boolean(short.liked)
-          }))
-        )
+
+        const formatted = Array.isArray(data.shorts)
+          ? data.shorts.map((short: any) => ({
+              ...short,
+              liked: Boolean(short.liked)
+            }))
+          : []
+
+        setShorts(formatted)
       } catch (err: any) {
         setError(err.message)
       } finally {


### PR DESCRIPTION
## Summary
- gracefully handle empty or failing shorts fetch
- show placeholder GIF when no shorts are available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68972b68ca70832788a3c2b74eb4f2be