### PR TITLE
feat: show spinner during profile update

### DIFF
--- a/src/modules/configuration/settings-panel/buttons/update-button.tsx
+++ b/src/modules/configuration/settings-panel/buttons/update-button.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { Check } from 'lucide-react'
+import { PulseLoader } from 'react-spinners'
 import { useTranslations } from 'next-intl'
 
 import { cn } from '@/lib/utils/classnames'
@@ -19,6 +20,7 @@ export default function UpdateButton() {
   let label = t('update')
   if (status === 'success') label = t('updated')
   if (status === 'error') label = t('updateFailed')
+  const loaderColor = activeTheme === 'light' ? '#000000' : '#ffffff'
 
   return (
     <button
@@ -30,15 +32,16 @@ export default function UpdateButton() {
         status === 'dirty' && 'animate-pulse dark:bg-[#26272C] bg-[#F4F4F4]'
       )}
     >
-      {label}
-      <span className='relative w-5 h-5'>
-        <Image
-          src={activeTheme === 'light' ? updateLightIcon : updateDarkIcon}
-          alt='Update icon'
-          className='w-5 h-5 aspect-square object-contain'
-        />
-        {status === 'success' && (
-          <Check className='absolute inset-0 w-5 h-5 text-green-600' />
+      {isPending ? <PulseLoader color={loaderColor} /> : label}
+      <span className='w-5 h-5 flex items-center justify-center'>
+        {status === 'success' ? (
+          <Check className='w-5 h-5 text-green-600' />
+        ) : (
+          <Image
+            src={activeTheme === 'light' ? updateLightIcon : updateDarkIcon}
+            alt='Update icon'
+            className='w-5 h-5 aspect-square object-contain'
+          />
         )}
       </span>
     </button>


### PR DESCRIPTION
## Summary
- show loading spinner while update is pending
- display green check when profile update completes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Dancing Script` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68972b4646ac8327b5f4375ea74314de