### PR TITLE
fix: remove duplicate streaming shorts route

### DIFF
--- a/src/app/[locale]/(features)/(streaming)/shorts/page.tsx
+++ b/src/app/[locale]/(features)/(streaming)/shorts/page.tsx
@@ -1,4 +1,0 @@
-// Shorts page
-export default function ShortsPage() {
-  return <h2>SHORTS PAGE</h2>
-}


### PR DESCRIPTION
## Summary
- remove streaming shorts route that conflicted with feed shorts page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts Figtree, Dancing Script, Shadows Into Light)*

------
https://chatgpt.com/codex/tasks/task_e_68972e7c768c8327ba1a1baf2de11e9e