### PR TITLE
fix: maintain Prisma connection

### DIFF
--- a/src/modules/configuration/profile-update/actions/get-user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/get-user-profile-action.ts
@@ -45,8 +45,6 @@ export default async function getUserProfileAction () {
   } catch (error) {
     console.error('Error fetching profile:', error)
     return null
-  } finally {
-    await db.$disconnect()
   }
 }
 

--- a/src/modules/configuration/profile-update/actions/phone-prefix-action.ts
+++ b/src/modules/configuration/profile-update/actions/phone-prefix-action.ts
@@ -29,7 +29,5 @@ export async function getPhonePrefixes() {
   } catch (error) {
     console.error('Error fetching phone prefixes:', error)
     throw error
-  } finally {
-    await db.$disconnect()
   }
 }

--- a/src/modules/configuration/profile-update/actions/user-gender-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-gender-action.ts
@@ -17,7 +17,5 @@ export async function getGenders() {
   } catch (error) {
     console.error('Error fetching genders:', error)
     throw error
-  } finally {
-    await db.$disconnect()
   }
 }

--- a/src/modules/configuration/profile-update/actions/user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-profile-action.ts
@@ -87,8 +87,6 @@ export default async function profileAction(values: Record<string, any>) {
   } catch (error) {
     console.error('Error updating profile:', error)
     return { error: 'Update failed' }
-  } finally {
-    await db.$disconnect()
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid disconnecting Prisma after fetching phone prefixes
- keep Prisma client alive when getting user profile
- remove Prisma disconnect in profile update and gender fetch actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689743ebb0f0832799ac689028a21f82