### PR TITLE
fix: maintain Prisma connection and show phone prefix

### DIFF
--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module 'next-auth' {
       following: number
       posts: number
       createdAt: string
+      prefix: string
     } & DefaultSession['user']
   }
   // Roles allowed in users
@@ -32,6 +33,7 @@ declare module 'next-auth/jwt' {
     following?: number
     posts?: number
     createdAt?: string
+    prefix?: string
   }
 }
 

--- a/src/data/users/get-user.ts
+++ b/src/data/users/get-user.ts
@@ -16,8 +16,11 @@ export const getUserByEmail = async (email: string) => {
 // Fetch user by ID
 export const getUserById = async (id: string) => {
   try {
-    // Search by ID
-    const user = await db.user.findUnique({ where: { id } })
+    // Search by ID and include phone prefix
+    const user = await db.user.findUnique({
+      where: { id },
+      include: { phonePrefix: true }
+    })
     // Return user if found
     return user
   } catch {

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -72,6 +72,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           session.user.following = token.following
         if (typeof token.posts === 'number') session.user.posts = token.posts
         if (token.createdAt) session.user.createdAt = token.createdAt as string
+        if (token.prefix) session.user.prefix = token.prefix as string
       }
 
       // Return the updated session
@@ -98,6 +99,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       token.following = existingUser.following
       token.posts = existingUser.posts
       token.createdAt = existingUser.createdAt.toISOString()
+      token.prefix = existingUser.phonePrefix?.prefix
 
       // Return the updated token
       return token

--- a/src/modules/configuration/profile-update/actions/get-user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/get-user-profile-action.ts
@@ -1,12 +1,11 @@
-'use server'
-
 // Auth
 import { auth } from '@/lib/auth/auth'
 
 // Database
 import { db } from '@/lib/orm/prisma-client'
 
-export default async function getUserProfileAction () {
+export default async function getUserProfileAction() {
+  'use server'
   const session = await auth()
   if (!session?.user?.id) {
     return null
@@ -45,8 +44,6 @@ export default async function getUserProfileAction () {
   } catch (error) {
     console.error('Error fetching profile:', error)
     return null
-  } finally {
-    await db.$disconnect()
   }
 }
 

--- a/src/modules/configuration/profile-update/actions/phone-prefix-action.ts
+++ b/src/modules/configuration/profile-update/actions/phone-prefix-action.ts
@@ -1,9 +1,8 @@
-'use server'
-
 // Prisma
 import { db } from '@/lib/orm/prisma-client'
 
 export async function getPhonePrefixes() {
+  'use server'
   try {
     const prefixes = await db.phonePrefix.findMany({
       select: {
@@ -29,7 +28,5 @@ export async function getPhonePrefixes() {
   } catch (error) {
     console.error('Error fetching phone prefixes:', error)
     throw error
-  } finally {
-    await db.$disconnect()
   }
 }

--- a/src/modules/configuration/profile-update/actions/user-gender-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-gender-action.ts
@@ -1,9 +1,8 @@
-'use server'
-
 // Prisma
 import { db } from '@/lib/orm/prisma-client'
 
 export async function getGenders() {
+  'use server'
   try {
     // Fetch all genders from the database
     const genders = await db.genders.findMany({
@@ -17,7 +16,5 @@ export async function getGenders() {
   } catch (error) {
     console.error('Error fetching genders:', error)
     throw error
-  } finally {
-    await db.$disconnect()
   }
 }

--- a/src/modules/configuration/profile-update/actions/user-profile-action.ts
+++ b/src/modules/configuration/profile-update/actions/user-profile-action.ts
@@ -1,5 +1,3 @@
-'use server'
-
 // Auth
 import { auth } from '@/lib/auth/auth'
 
@@ -12,6 +10,7 @@ import { getUserById } from '@/data/users/get-user'
 import bcrypt from 'bcryptjs'
 
 export default async function profileAction(values: Record<string, any>) {
+  'use server'
   const session = await auth()
   if (!session?.user?.id) {
     return { error: 'Unauthorized' }
@@ -87,8 +86,6 @@ export default async function profileAction(values: Record<string, any>) {
   } catch (error) {
     console.error('Error updating profile:', error)
     return { error: 'Update failed' }
-  } finally {
-    await db.$disconnect()
   }
 }
 

--- a/src/modules/configuration/profile-update/components/inputs/phone-prefix-input.tsx
+++ b/src/modules/configuration/profile-update/components/inputs/phone-prefix-input.tsx
@@ -38,7 +38,7 @@ const PhonePrefixInput = ({ name, isPending }: PhonePrefixInputProps) => {
   const dropdownRef = useRef<HTMLUListElement>(null)
   const { session, hydrated } = useUserSession()
   const [userPhonePrefix, setuserPhonePrefix] = useState<string | undefined>('')
-  const { watch } = useFormContext()
+  const { watch, setValue } = useFormContext()
   const fieldValue = watch<string>(name)
 
   useEffect(() => {
@@ -52,8 +52,15 @@ const PhonePrefixInput = ({ name, isPending }: PhonePrefixInputProps) => {
   }, [fieldValue])
 
   useEffect(() => {
-    if (hydrated) setuserPhonePrefix(session?.user?.prefix || '')
-  }, [hydrated, session, t])
+    if (!hydrated) return
+    const prefix = session?.user?.prefix || ''
+    setuserPhonePrefix(prefix)
+    if (!fieldValue && prefix) {
+      setValue(name, prefix)
+      setSearch(prefix)
+      setHasSelected(true)
+    }
+  }, [hydrated, session, fieldValue, name, setValue])
 
   useEffect(() => {
     async function fetchPrefixes() {


### PR DESCRIPTION
## Summary
- avoid disconnecting Prisma after fetching phone prefixes
- keep Prisma client alive when getting user profile
- remove Prisma disconnect in profile update and gender fetch actions
- include phone prefix in JWT/session and prefill profile form
- convert profile actions to function-level server actions so client components load prefixes and other options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689743ebb0f0832799ac689028a21f82